### PR TITLE
Added color modifier for green-circuit

### DIFF
--- a/gallery/packages/animation.63.green-circuit/package.yaml
+++ b/gallery/packages/animation.63.green-circuit/package.yaml
@@ -2,8 +2,11 @@ version: v1
 metadata:
   name: Green Circuit
   description: I'm in
-  author: Jared Stanley
+  author: Jared Stanley, modified by Sjors Kaamgan
   source: https://codepen.io/ykob/pen/YewoRz
+parameters:
+  - id: textColor
+    default: "rgba(22,222,82,0.6992)"
 helpers:
   insert_baseurl: true
 template: >
@@ -32,7 +35,7 @@ template: >
           dotCount = 1333,
           speedMax = 1.0,
           dotArray = [];
-        let clr = "rgba(22,222,82,0.6992)";
+        let clr = "{{parameter: textColor}}";
         //
         window.onload = function () {
           start();

--- a/gallery/packages/animation.63.green-circuit/package.yaml
+++ b/gallery/packages/animation.63.green-circuit/package.yaml
@@ -2,7 +2,7 @@ version: v1
 metadata:
   name: Green Circuit
   description: I'm in
-  author: Jared Stanley, modified by Sjors Kaamgan
+  author: Jared Stanley, modified by Sjors Kaagman
   source: https://codepen.io/ykob/pen/YewoRz
 parameters:
   - id: textColor


### PR DESCRIPTION
Allow you to change the color for green-circuit with the textColor param, e.g.
```
        - id: animation.63.green-circuit
          parameters:
            textColor: "rgba(88,8,25,0.6992)"
```

this would result in something like this:
<img width="1178" alt="Screenshot 2025-02-27 at 16 12 20" src="https://github.com/user-attachments/assets/bb9ffc8b-9263-428b-b200-4bfc772732fd" />


Based on the Reply by [ibz0q](https://github.com/ibz0q) @ [this discussion](https://github.com/ibz0q/lovelace-bg-animation/discussions/11#discussioncomment-12332148) 

Not so green anymore :p
Might peek at the other backgrounds too in the future ;)