### PR TITLE
PS3 bg darkmode fix

### DIFF
--- a/dist/gallery/gallery.manifest
+++ b/dist/gallery/gallery.manifest
@@ -1047,7 +1047,7 @@
       "description": "RetroArch Menu Ribbon",
       "author": "Boris Šehovac",
       "source": "https://codepen.io/bsehovac/pen/jdawXK",
-      "hash": "39417188085d20c2a8a70a2a9201a724d22c1f75",
+      "hash": "0fb60a01bf5b9118e80df8cc263deb66b72f21a0",
       "parameters": [
         {
           "name": "waveColor",

--- a/dist/gallery/packages/animation.72.playstation-3-bg-style/package.yaml
+++ b/dist/gallery/packages/animation.72.playstation-3-bg-style/package.yaml
@@ -32,6 +32,7 @@ template: >
           bottom: 0;
           margin: 0;
           overflow: hidden;
+          background-color: #000;
         }
 
         #container {

--- a/gallery/gallery.manifest
+++ b/gallery/gallery.manifest
@@ -1047,7 +1047,7 @@
       "description": "RetroArch Menu Ribbon",
       "author": "Boris Šehovac",
       "source": "https://codepen.io/bsehovac/pen/jdawXK",
-      "hash": "39417188085d20c2a8a70a2a9201a724d22c1f75",
+      "hash": "0fb60a01bf5b9118e80df8cc263deb66b72f21a0",
       "parameters": [
         {
           "name": "waveColor",

--- a/gallery/packages/animation.72.playstation-3-bg-style/package.yaml
+++ b/gallery/packages/animation.72.playstation-3-bg-style/package.yaml
@@ -32,6 +32,7 @@ template: >
           bottom: 0;
           margin: 0;
           overflow: hidden;
+          background-color: #000;
         }
 
         #container {


### PR DESCRIPTION
This fixes an issue caused by Dark Mode on mobile, where the top bit would turn white (very specific issue, never ran into it until I used it as my main). 
This issue was not present on Light Mode, and the fix does not affect it either (double checked it).

![photo_2025-08-09_15-39-42](https://github.com/user-attachments/assets/3dfc1c8d-2d81-40cb-9f4b-f0ffb03b392f)
![photo_2025-08-09_15-39-43](https://github.com/user-attachments/assets/ab703fb7-aa8a-470a-9720-2f1d236ef353)
